### PR TITLE
Debian packaging rebase

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+msttcorefonts (3.8.1-pop1) jammy; urgency=medium
+
+  * Backport to Pop 22.04
+
+ -- Michael Murphy <michael@mmurphy.dev>  Wed, 22 Feb 2023 17:37:33 +0100
+
 msttcorefonts (3.8.1) unstable; urgency=medium
 
   * Correct directory name for READ_ME!.gz (closes: #996010).

--- a/debian/clean
+++ b/debian/clean
@@ -1,1 +1,0 @@
-debian/postinst

--- a/debian/config
+++ b/debian/config
@@ -68,6 +68,9 @@ for f in $SHA256SUMS ; do
 done
 
 if [ -n "$NEEDUPDATE" ] ; then
+  rm -f /var/lib/update-notifier/package-data-downloads/ttf-mscorefonts-installer \
+        /var/lib/update-notifier/package-data-downloads/ttf-mscorefonts-installer.*
+
   db_input low msttcorefonts/dldir || true
   if [ -n "$http_proxy" ] ; then
     db_set msttcorefonts/http_proxy $http_proxy

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Browser: https://salsa.debian.org/debian/msttcorefonts
 
 Package: ttf-mscorefonts-installer
 Architecture: all
-Pre-Depends: ${misc:Pre-Depends}
+Pre-Depends: ${misc:Pre-Depends}, debconf
 Depends: wget, ca-certificates, cabextract, xfonts-utils, ${misc:Depends}
 Recommends: fonts-liberation
 Provides: msttcorefonts

--- a/debian/install
+++ b/debian/install
@@ -1,1 +1,2 @@
 cabfiles.sha256sums	/var/lib/msttcorefonts
+usr/share/package-data-downloads

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,534 @@
+#!/bin/sh
+set -e
+
+. /usr/share/debconf/confmodule
+
+db_get msttcorefonts/dldir
+LOCALCOPY=$RET
+
+db_get msttcorefonts/savedir
+SAVEDIR=$RET
+
+db_get msttcorefonts/dlurl
+URLOVERRIDE=$RET
+
+db_get msttcorefonts/http_proxy
+http_proxy=$RET
+
+while ! echo "$http_proxy" | \
+    egrep -iq 'https?://[[:alnum:]][-.[:alnum:]]+(:\d+)?/?' &&  \
+    [ ! -z "$http_proxy" ] ; do
+        db_fset msttcorefonts/http_proxy seen false
+        db_input high msttcorefonts/http_proxy
+        db_go
+        db_get msttcorefonts/http_proxy
+        http_proxy=$RET
+done
+
+## Content of update-ms-fonts will be concatenated below
+
+#!/bin/sh
+# Download and install the Microsoft Core Fonts for the Web
+#
+# (C) 2000,2001 Eric Sharkey.
+# You may freely distribute this file under the terms of the GNU General
+# Public License, version 2 or later.
+
+#abort if anything goes wrong
+#set -e
+FONTDIR=/usr/share/fonts/truetype/msttcorefonts
+
+#if [ `id -u` != 0 ] ; then
+#  echo "update-ms-fonts can only be run as root."
+#  exit -1
+#fi
+#
+#for opt in "$@"; do
+#    case "$opt" in
+#        -q) QUIET_MODE=1 ;;
+#        -c) CHECK_ONLY=1 ;;
+#        -s*) SAVEDIR=${opt#-s} ;;
+#        -u*) URLOVERRIDE=${opt#-u} ;;
+#        *) LOCALCOPY=$opt ;;
+#    esac
+#done
+if [ "`echo $LOCALCOPY | tr '[:upper:]' '[:lower:]'`" = "none" ] ; then
+  exit 0
+fi
+
+EXITCODE=0
+
+export http_proxy
+
+mstt_exit_with_error() {
+    echo "$1" >&2
+    echo "The fonts are NOT installed." >&2
+    echo "Please run 'dpkg-reconfigure ttf-mscorefonts-installer' to perform the installation again" >&2
+    exit 1
+}
+
+# Base URL for Microsoft fonts
+# Can be more than one to try, but here we just use SF.net's redirection,
+# which will work in most cases. The others serve as fallbacks to retry.
+URLROOTS="https://downloads.sourceforge.net/corefonts/
+	https://jaist.dl.sourceforge.net/sourceforge/corefonts/
+	https://nchc.dl.sourceforge.net/sourceforge/corefonts/
+	https://ufpr.dl.sourceforge.net/sourceforge/corefonts/
+	https://internode.dl.sourceforge.net/sourceforge/corefonts/
+	https://netcologne.dl.sourceforge.net/sourceforge/corefonts/
+	https://vorboss.dl.sourceforge.net/sourceforge/corefonts/
+	https://netix.dl.sourceforge.net/sourceforge/corefonts/"
+
+if [ "$URLOVERRIDE" ] ; then
+    URLROOTS="$URLOVERRIDE"
+fi
+
+SCRATCHDIR=`mktemp -t -d ttf-mscorefonts-installer.XXXXXX`
+chmod 0755 $SCRATCHDIR
+cd $SCRATCHDIR
+
+cat <<EOF > msfonts.info
+48d9bc613917709d3b0e0f4a6d4fe33a5c544c5035dffe9e90bc11e50e822071	Andale_Mono.ttf		andale32.exe	andalemo.ttf
+dad7c04acb26e23dfe4780e79375ca193ddaf68409317e81577a30674668830e	Arial_Black.ttf		arialb32.exe	ariblk.ttf
+35c0f3559d8db569e36c31095b8a60d441643d95f59139de40e23fada819b833	Arial.ttf		arial32.exe	arial.ttf
+4044aa6b5bebbc36980206b45b0aaaaa5681552a48bcadb41746d5d1d71fd7b4	Arial_Bold.ttf		arial32.exe	arialbd.ttf
+2f371cd9d96b3ac544519d85c16dc43ceacdfcea35090ee8ddf3ec5857c50328	Arial_Bold_Italic.ttf	arial32.exe	arialbi.ttf
+70ade233175a6a6675e4501461af9326e6f78b1ffdf787ca0da5ab0fc8c9cfd6	Arial_Italic.ttf	arial32.exe	ariali.ttf
+b82c53776058f291382ff7e008d4675839d2dc21eb295c66391f6fb0655d8fc0	Comic_Sans_MS.ttf	comic32.exe	comic.ttf
+873361465d994994762d0b9845c99fc7baa2a600442ea8db713a7dd19f8b0172	Comic_Sans_MS_Bold.ttf	comic32.exe	comicbd.ttf
+6715838c52f813f3821549d3f645db9a768bd6f3a43d8f85a89cb6875a546c61	Courier_New.ttf		courie32.exe	cour.ttf
+edf8a7c5bfcac2e1fe507faab417137cbddc9071637ef4648238d0768c921e02	Courier_New_Bold.ttf	courie32.exe	courbd.ttf
+f3f6b09855b6700977e214aab5eb9e5be6813976a24f894bd7766e92c732fbe1	Courier_New_Italic.ttf	courie32.exe	couri.ttf
+66dbfa20b534fba0e203da140fec7276a45a1069e424b1b9c35547538128bbe8	Courier_New_Bold_Italic.ttf	courie32.exe	courbi.ttf
+7d0bb20c632bb59e81a0885f573bd2173f71f73204de9058feb68ce032227072	Georgia.ttf		georgi32.exe	georgia.ttf
+82d2fbadb88a8632d7f2e8ad50420c9fd2e7d3cbc0e90b04890213a711b34b93	Georgia_Bold.ttf	georgi32.exe	georgiab.ttf
+1523f19bda6acca42c47c50da719a12dd34f85cc2606e6a5af15a7728b377b60	Georgia_Italic.ttf	georgi32.exe	georgiai.ttf
+c983e037d8e4e694dd0fb0ba2e625bca317d67a41da2dc81e46a374e53d0ec8a	Georgia_Bold_Italic.ttf	georgi32.exe	georgiaz.ttf
+00f1fc230ac99f9b97ba1a7c214eb5b909a78660cb3826fca7d64c3af5a14848	Impact.ttf		impact32.exe	impact.ttf
+4e98adeff8ccc8ef4e3ece8d4547e288ff85fdc9c7ca711a4599c234874bbe86	Times_New_Roman.ttf	times32.exe	times.ttf
+4357b63cef20c01661a53c5dae70ffd20cb4765503aaed6d38b17a57c5a90bff	Times_New_Roman_Bold.ttf	times32.exe	timesbd.ttf
+192e1b0d18e90334e999a99f8c32808d6a2e74b3698b8cd90c943c2249a46549	Times_New_Roman_Bold_Italic.ttf	times32.exe	timesbi.ttf
+c25ae529b4cecdbca148b6ccb862ee0abad770af8b1fd29c8dba619d1b8da78a	Times_New_Roman_Italic.ttf	times32.exe	timesi.ttf
+ec3ffb302488251e1b67fb09dd578b364c5339e27c1cfb26eb627666236453d0	Trebuchet_MS.ttf	trebuc32.exe	trebuc.ttf
+f65941f9487c0a0a3b7445996ecbbd24466d7ae76ea2a597ced55f438fa63838	Trebuchet_MS_Bold.ttf	trebuc32.exe	trebucbd.ttf
+db56fdac7d3ba20b7aededcb6ee86c46687489d17b759e1708ea4e2d21e38410	Trebuchet_MS_Italic.ttf	trebuc32.exe	trebucit.ttf
+c0a6bdf31f9f2953b2f08a0c1734c892bc825f0fb17c604d420f7acf203a213b	Trebuchet_MS_Bold_Italic.ttf	trebuc32.exe	trebucbi.ttf
+96ed14949ca4b7392cff235b9c41d55c125382abbe0c0d3c2b9dd66897cae0cb	Verdana.ttf		verdan32.exe	verdana.ttf
+c8f5065ba91680f596af3b0378e2c3e713b95a523be3d56ae185ca2b8f5f0b23	Verdana_Bold.ttf	verdan32.exe	verdanab.ttf
+91b59186656f52972531a11433c866fd56e62ec4e61e2621a2dba70c8f19a828	Verdana_Italic.ttf	verdan32.exe	verdanai.ttf
+698e220f48f4a40e77af7eb34958c8fd02f1e18c3ba3f365d93bfa2ed4474c80	Verdana_Bold_Italic.ttf	verdan32.exe	verdanaz.ttf
+10d099c88521b1b9e380b7690cbe47b54bb19396ca515358cfdc15ac249e2f5d	Webdings.ttf		webdin32.exe	webdings.ttf
+EOF
+
+for ttf in `awk '{print $2}' msfonts.info` ; do
+    if [ ! -e $FONTDIR/$ttf ] || \
+        [ `sha256sum $FONTDIR/$ttf | awk '{print $1}'` != `awk "/$ttf/ {print \\$1 }" msfonts.info` ]
+        then
+        THISFILE=`grep $ttf msfonts.info | awk '{print $3}'`
+        if ! echo $FONTFILES | grep -q $THISFILE ; then
+            FONTFILES="$FONTFILES $THISFILE"
+        fi
+    fi
+done
+
+FFDONE=""
+FFFAILED=""
+if [ -n "$CHECK_ONLY" ] ; then
+    if [ -n "$FONTFILES" ] ; then
+        EXITCODE=1
+    fi
+elif [ -n "$FONTFILES" ] ; then 
+
+    if [ -z "$QUIET_MODE" ] ; then
+        cat <<EOF
+
+These fonts were provided by Microsoft "in the interest of cross-
+platform compatibility".  This is no longer the case, but they are
+still available from third parties.
+
+You are free to download these fonts and use them for your own use,
+but you may not redistribute them in modified form, including changes
+to the file name or packaging format.
+
+EOF
+    fi
+
+    if [ -n "$QUIET_MODE" ] ; then
+        QUIET_ARG="--quiet"
+    else
+        QUIET_ARG=""
+    fi
+    for ff in $FONTFILES; do
+        for URLROOT in $URLROOTS ; do
+            if [ ! -e $ff.done ] || [ ! -e $ff ] ; then
+                if [ -z "$LOCALCOPY" ] ; then
+                    if ! wget --continue --tries=1 --connect-timeout=60 --read-timeout=300 $QUIET_ARG --directory-prefix . --no-directories --no-background --progress=dot:default $URLROOT$ff ; then
+                        continue 1
+                    fi
+                else
+                    cp $LOCALCOPY/$ff .
+                fi
+                touch $ff.done
+                break
+            fi
+        done
+        if [ -e "$ff" ]; then
+            FFDONE="$FFDONE $ff"
+        else 
+            FFFAILED="$FFFAILED $ff"
+            EXITCODE=1
+        fi   
+    done
+    if [ -n "$SAVEDIR" ] ; then
+        mkdir -p "$SAVEDIR"
+    fi
+
+    # Reset counters for checksum
+    FONTFILES=$FFDONE
+    FFDONE=""
+
+    for ff in $FONTFILES; do
+        # verify checksum before unpacking, to be safe
+        if grep "$ff\$" /var/lib/msttcorefonts/cabfiles.sha256sums | sha256sum -c ; then
+                cabextract $ff 1>&2
+                FFDONE="$FFDONE $ff"
+        else
+            FFFAILED="$FFFAILED $ff"
+            EXITCODE=1
+        fi
+        if [ -n "$SAVEDIR" ] ; then
+            cp $ff "$SAVEDIR"
+        fi
+        rm $ff
+    done
+
+    FONTFILES=$FFDONE
+    FFDONE=""
+  #Add some level of predictability by folding everything to lower case
+    for x in *; do
+        y=`echo $x | tr '[A-Z]' '[a-z]'`
+        if [ "$x" != "$y" ]; then
+            mv "$x" "$y"
+        fi
+    done
+    
+    chmod 644 *
+    
+  # Give sane names. These are nearly the same names MS uses for the
+  # Macintosh versions
+    
+    mkdir -p /usr/share/doc/ttf-mscorefonts-installer $FONTDIR
+    if [ -e licen.txt ] ; then
+        mv licen.txt '/usr/share/doc/ttf-mscorefonts-installer/READ_ME!'
+        gzip -f -9 '/usr/share/doc/ttf-mscorefonts-installer/READ_ME!'
+    fi
+    for ff in $FONTFILES; do
+        for ttf in `grep $ff msfonts.info | awk '{print $4}'`; do
+            longname=`awk "/$ttf/ { print \\$2 }" msfonts.info`
+            mv -Z $ttf $FONTDIR/$longname
+            ln -sf $longname $FONTDIR/$ttf
+        done
+    done
+    
+  # Make a note of what we installed so we can uninstall it later
+    awk '{print $2}' msfonts.info > /var/lib/msttcorefonts/ms-fonts
+    awk '{print $4}' msfonts.info >> /var/lib/msttcorefonts/ms-fonts
+
+    dpkg-trigger --no-await /usr/share/fonts
+fi
+
+cd /
+rm -rf $SCRATCHDIR
+
+if [ -z "$QUIETMODE" ] ; then
+    if [ $EXITCODE = 0 ] ; then
+        echo "All fonts downloaded and installed."
+    else
+        if [ -n "$FFFAILED" ]; then
+            mstt_exit_with_error "The following fonts failed to install : $FFFAILED."
+        else
+            mstt_exit_with_error "One or more fonts could not be extracted."
+        fi
+    fi
+fi
+
+#DEBHELPER#
+
+exit $EXITCODE
+#!/bin/sh
+set -e
+
+. /usr/share/debconf/confmodule
+
+db_get msttcorefonts/dldir
+LOCALCOPY=$RET
+
+db_get msttcorefonts/savedir
+SAVEDIR=$RET
+
+db_get msttcorefonts/dlurl
+URLOVERRIDE=$RET
+
+db_get msttcorefonts/http_proxy
+http_proxy=$RET
+
+while ! echo "$http_proxy" | \
+    egrep -iq 'https?://[[:alnum:]][-.[:alnum:]]+(:\d+)?/?' &&  \
+    [ ! -z "$http_proxy" ] ; do
+        db_fset msttcorefonts/http_proxy seen false
+        db_input high msttcorefonts/http_proxy
+        db_go
+        db_get msttcorefonts/http_proxy
+        http_proxy=$RET
+done
+
+## Content of update-ms-fonts will be concatenated below
+
+#!/bin/sh
+# Download and install the Microsoft Core Fonts for the Web
+#
+# (C) 2000,2001 Eric Sharkey.
+# You may freely distribute this file under the terms of the GNU General
+# Public License, version 2 or later.
+
+#set -e
+#. /usr/share/debconf/confmodule
+
+FONTDIR=/usr/share/fonts/truetype/msttcorefonts
+
+#if [ `id -u` != 0 ] ; then
+#  echo "update-ms-fonts can only be run as root."
+#  exit -1
+#fi
+#
+#for opt in "$@"; do
+#    case "$opt" in
+#        -q) QUIET_MODE=1 ;;
+#        -c) CHECK_ONLY=1 ;;
+#        -s*) SAVEDIR=${opt#-s} ;;
+#        -u*) URLOVERRIDE=${opt#-u} ;;
+#        *) LOCALCOPY=$opt ;;
+#    esac
+#done
+if [ "`echo $LOCALCOPY | tr '[:upper:]' '[:lower:]'`" = "none" ] ; then
+  exit 0
+fi
+
+EXITCODE=0
+
+export http_proxy
+
+mstt_exit_with_error() {
+    echo "$1" >&2
+    echo "The fonts are NOT installed." >&2
+    echo "Please run 'dpkg-reconfigure ttf-mscorefonts-installer' to perform the installation again" >&2
+    exit 1
+}
+
+# Base URL for Microsoft fonts
+# Can be more than one to try, but here we just use SF.net's redirection,
+# which will work in most cases. The others serve as fallbacks to retry.
+URLROOTS="https://downloads.sourceforge.net/corefonts/
+	https://jaist.dl.sourceforge.net/sourceforge/corefonts/
+	https://nchc.dl.sourceforge.net/sourceforge/corefonts/
+	https://ufpr.dl.sourceforge.net/sourceforge/corefonts/
+	https://internode.dl.sourceforge.net/sourceforge/corefonts/
+	https://netcologne.dl.sourceforge.net/sourceforge/corefonts/
+	https://vorboss.dl.sourceforge.net/sourceforge/corefonts/
+	https://netix.dl.sourceforge.net/sourceforge/corefonts/"
+
+if [ "$URLOVERRIDE" ] ; then
+    URLROOTS="$URLOVERRIDE"
+fi
+
+db_get msttcorefonts/accepted-mscorefonts-eula || true
+if [ "$RET" != "true" ]; then
+    mstt_exit_with_error "user did not accept the $license license"
+fi
+
+if [ -z "$QUIET_MODE" ] ; then
+    cat <<EOF
+
+These fonts were provided by Microsoft "in the interest of cross-
+platform compatibility".  This is no longer the case, but they are
+still available from third parties.
+
+You are free to download these fonts and use them for your own use,
+but you may not redistribute them in modified form, including changes
+to the file name or packaging format.
+
+EOF
+fi
+
+SCRATCHDIR=`mktemp -t -d ttf-mscorefonts-installer.XXXXXX`
+chmod 0755 $SCRATCHDIR
+cd $SCRATCHDIR
+
+cat <<EOF > msfonts.info
+48d9bc613917709d3b0e0f4a6d4fe33a5c544c5035dffe9e90bc11e50e822071	Andale_Mono.ttf		andale32.exe	andalemo.ttf
+dad7c04acb26e23dfe4780e79375ca193ddaf68409317e81577a30674668830e	Arial_Black.ttf		arialb32.exe	ariblk.ttf
+35c0f3559d8db569e36c31095b8a60d441643d95f59139de40e23fada819b833	Arial.ttf		arial32.exe	arial.ttf
+4044aa6b5bebbc36980206b45b0aaaaa5681552a48bcadb41746d5d1d71fd7b4	Arial_Bold.ttf		arial32.exe	arialbd.ttf
+2f371cd9d96b3ac544519d85c16dc43ceacdfcea35090ee8ddf3ec5857c50328	Arial_Bold_Italic.ttf	arial32.exe	arialbi.ttf
+70ade233175a6a6675e4501461af9326e6f78b1ffdf787ca0da5ab0fc8c9cfd6	Arial_Italic.ttf	arial32.exe	ariali.ttf
+b82c53776058f291382ff7e008d4675839d2dc21eb295c66391f6fb0655d8fc0	Comic_Sans_MS.ttf	comic32.exe	comic.ttf
+873361465d994994762d0b9845c99fc7baa2a600442ea8db713a7dd19f8b0172	Comic_Sans_MS_Bold.ttf	comic32.exe	comicbd.ttf
+6715838c52f813f3821549d3f645db9a768bd6f3a43d8f85a89cb6875a546c61	Courier_New.ttf		courie32.exe	cour.ttf
+edf8a7c5bfcac2e1fe507faab417137cbddc9071637ef4648238d0768c921e02	Courier_New_Bold.ttf	courie32.exe	courbd.ttf
+f3f6b09855b6700977e214aab5eb9e5be6813976a24f894bd7766e92c732fbe1	Courier_New_Italic.ttf	courie32.exe	couri.ttf
+66dbfa20b534fba0e203da140fec7276a45a1069e424b1b9c35547538128bbe8	Courier_New_Bold_Italic.ttf	courie32.exe	courbi.ttf
+7d0bb20c632bb59e81a0885f573bd2173f71f73204de9058feb68ce032227072	Georgia.ttf		georgi32.exe	georgia.ttf
+82d2fbadb88a8632d7f2e8ad50420c9fd2e7d3cbc0e90b04890213a711b34b93	Georgia_Bold.ttf	georgi32.exe	georgiab.ttf
+1523f19bda6acca42c47c50da719a12dd34f85cc2606e6a5af15a7728b377b60	Georgia_Italic.ttf	georgi32.exe	georgiai.ttf
+c983e037d8e4e694dd0fb0ba2e625bca317d67a41da2dc81e46a374e53d0ec8a	Georgia_Bold_Italic.ttf	georgi32.exe	georgiaz.ttf
+00f1fc230ac99f9b97ba1a7c214eb5b909a78660cb3826fca7d64c3af5a14848	Impact.ttf		impact32.exe	impact.ttf
+4e98adeff8ccc8ef4e3ece8d4547e288ff85fdc9c7ca711a4599c234874bbe86	Times_New_Roman.ttf	times32.exe	times.ttf
+4357b63cef20c01661a53c5dae70ffd20cb4765503aaed6d38b17a57c5a90bff	Times_New_Roman_Bold.ttf	times32.exe	timesbd.ttf
+192e1b0d18e90334e999a99f8c32808d6a2e74b3698b8cd90c943c2249a46549	Times_New_Roman_Bold_Italic.ttf	times32.exe	timesbi.ttf
+c25ae529b4cecdbca148b6ccb862ee0abad770af8b1fd29c8dba619d1b8da78a	Times_New_Roman_Italic.ttf	times32.exe	timesi.ttf
+ec3ffb302488251e1b67fb09dd578b364c5339e27c1cfb26eb627666236453d0	Trebuchet_MS.ttf	trebuc32.exe	trebuc.ttf
+f65941f9487c0a0a3b7445996ecbbd24466d7ae76ea2a597ced55f438fa63838	Trebuchet_MS_Bold.ttf	trebuc32.exe	trebucbd.ttf
+db56fdac7d3ba20b7aededcb6ee86c46687489d17b759e1708ea4e2d21e38410	Trebuchet_MS_Italic.ttf	trebuc32.exe	trebucit.ttf
+c0a6bdf31f9f2953b2f08a0c1734c892bc825f0fb17c604d420f7acf203a213b	Trebuchet_MS_Bold_Italic.ttf	trebuc32.exe	trebucbi.ttf
+96ed14949ca4b7392cff235b9c41d55c125382abbe0c0d3c2b9dd66897cae0cb	Verdana.ttf		verdan32.exe	verdana.ttf
+c8f5065ba91680f596af3b0378e2c3e713b95a523be3d56ae185ca2b8f5f0b23	Verdana_Bold.ttf	verdan32.exe	verdanab.ttf
+91b59186656f52972531a11433c866fd56e62ec4e61e2621a2dba70c8f19a828	Verdana_Italic.ttf	verdan32.exe	verdanai.ttf
+698e220f48f4a40e77af7eb34958c8fd02f1e18c3ba3f365d93bfa2ed4474c80	Verdana_Bold_Italic.ttf	verdan32.exe	verdanaz.ttf
+10d099c88521b1b9e380b7690cbe47b54bb19396ca515358cfdc15ac249e2f5d	Webdings.ttf		webdin32.exe	webdings.ttf
+EOF
+
+for ttf in `awk '{print $2}' msfonts.info` ; do
+    if [ ! -e $FONTDIR/$ttf ] || \
+        [ `sha256sum $FONTDIR/$ttf | awk '{print $1}'` != `awk "/$ttf/ {print \\$1 }" msfonts.info` ]
+        then
+        THISFILE=`grep $ttf msfonts.info | awk '{print $3}'`
+        if ! echo $FONTFILES | grep -q $THISFILE ; then
+            FONTFILES="$FONTFILES $THISFILE"
+        fi
+    fi
+done
+
+FFDONE=""
+FFFAILED=""
+if [ -n "$CHECK_ONLY" ] ; then
+    if [ -n "$FONTFILES" ] ; then
+        EXITCODE=1
+    fi
+elif [ -n "$FONTFILES" ] ; then 
+
+    if [ -z "$QUIET_MODE" ] ; then
+        cat <<EOF
+
+These fonts were provided by Microsoft "in the interest of cross-
+platform compatibility".  This is no longer the case, but they are
+still available from third parties.
+
+You are free to download these fonts and use them for your own use,
+but you may not redistribute them in modified form, including changes
+to the file name or packaging format.
+
+EOF
+    fi
+
+    if [ -n "$QUIET_MODE" ] ; then
+        QUIET_ARG="--quiet"
+    else
+        QUIET_ARG=""
+    fi
+    for ff in $FONTFILES; do
+        for URLROOT in $URLROOTS ; do
+            if [ ! -e $ff.done ] || [ ! -e $ff ] ; then
+                if [ -z "$LOCALCOPY" ] ; then
+                    if ! wget --continue --tries=1 --connect-timeout=60 --read-timeout=300 $QUIET_ARG --directory-prefix . --no-directories --no-background --progress=dot:default $URLROOT$ff ; then
+                        continue 1
+                    fi
+                else
+                    cp $LOCALCOPY/$ff .
+                fi
+                touch $ff.done
+                break
+            fi
+        done
+        if [ -e "$ff" ]; then
+            FFDONE="$FFDONE $ff"
+        else 
+            FFFAILED="$FFFAILED $ff"
+            EXITCODE=1
+        fi   
+    done
+    if [ -n "$SAVEDIR" ] ; then
+        mkdir -p "$SAVEDIR"
+    fi
+
+    # Reset counters for checksum
+    FONTFILES=$FFDONE
+    FFDONE=""
+
+    for ff in $FONTFILES; do
+        # verify checksum before unpacking, to be safe
+        if grep "$ff\$" /var/lib/msttcorefonts/cabfiles.sha256sums | sha256sum -c ; then
+                cabextract $ff 1>&2
+                FFDONE="$FFDONE $ff"
+        else
+            FFFAILED="$FFFAILED $ff"
+            EXITCODE=1
+        fi
+        if [ -n "$SAVEDIR" ] ; then
+            cp $ff "$SAVEDIR"
+        fi
+        rm $ff
+    done
+
+    FONTFILES=$FFDONE
+    FFDONE=""
+  #Add some level of predictability by folding everything to lower case
+    for x in *; do
+        y=`echo $x | tr '[A-Z]' '[a-z]'`
+        if [ "$x" != "$y" ]; then
+            mv "$x" "$y"
+        fi
+    done
+    
+    chmod 644 *
+    
+  # Give sane names. These are nearly the same names MS uses for the
+  # Macintosh versions
+    
+    mkdir -p /usr/share/doc/ttf-mscorefonts-installer $FONTDIR
+    if [ -e licen.txt ] ; then
+        mv licen.txt '/usr/share/doc/ttf-mscorefonts-installer/READ_ME!'
+        gzip -f -9 '/usr/share/doc/ttf-mscorefonts-installer/READ_ME!'
+    fi
+    for ff in $FONTFILES; do
+        for ttf in `grep $ff msfonts.info | awk '{print $4}'`; do
+            longname=`awk "/$ttf/ { print \\$2 }" msfonts.info`
+            mv -Z $ttf $FONTDIR/$longname
+            ln -sf $longname $FONTDIR/$ttf
+        done
+    done
+    
+  # Make a note of what we installed so we can uninstall it later
+    awk '{print $2}' msfonts.info > /var/lib/msttcorefonts/ms-fonts
+    awk '{print $4}' msfonts.info >> /var/lib/msttcorefonts/ms-fonts
+
+    dpkg-trigger --no-await /usr/share/fonts
+fi
+
+cd /
+rm -rf $SCRATCHDIR
+
+if [ -z "$QUIETMODE" ] ; then
+    if [ $EXITCODE = 0 ] ; then
+        echo "All fonts downloaded and installed."
+    else
+        if [ -n "$FFFAILED" ]; then
+            mstt_exit_with_error "The following fonts failed to install : $FFFAILED."
+        else
+            mstt_exit_with_error "One or more fonts could not be extracted."
+        fi
+    fi
+fi
+
+#DEBHELPER#
+
+exit $EXITCODE

--- a/debian/preinst
+++ b/debian/preinst
@@ -1,0 +1,75 @@
+#!/bin/sh -e
+
+. /usr/share/debconf/confmodule
+db_version 2.0
+db_capb backup
+
+#DEBHELPER#
+
+license=mscorefonts-eula
+
+errmsg()
+{
+    echo >&2 ''
+    echo >&2 "$@"
+    echo >&2 "try 'dpkg-reconfigure debconf' to select a frontend other than noninteractive"
+    echo >&2 ''
+}
+
+db_get msttcorefonts/accepted-$license
+if [ "$RET" = "true" ]; then
+    echo "$license license has already been accepted" >&2
+    exit 0
+else
+    # show license again
+    db_fset msttcorefonts/present-$license seen false
+fi
+
+# facilitate backup capability per debconf-devel(7)
+STATE=1
+while true; do
+    case "$STATE" in
+    0)  # ensure going back from license presentment is harmless
+        STATE=1
+        continue
+        ;;
+    1)  # present license
+        db_fset msttcorefonts/present-$license seen false
+        if ! db_input critical msttcorefonts/present-$license ; then
+            errmsg "$license license could not be presented"
+            exit 0
+        fi
+        db_fset msttcorefonts/accepted-$license seen false
+        if ! db_input critical msttcorefonts/accepted-$license ; then
+            errmsg "$license agree question could not be asked"
+            exit 0
+        fi
+        ;;
+    2)  # determine users' choice
+        db_get msttcorefonts/accepted-$license
+        if [ "$RET" = "true" ]; then
+            # license accepted
+            exit 0
+        fi
+        # error on decline license (give user chance to back up)
+        db_input critical msttcorefonts/error-$license
+        ;;
+    3)  # user has confirmed declining license
+        echo "user did not accept the $license license" >&2
+        exit 0
+        ;;
+    *)  # unknown state
+        echo "$license license state unknown: $STATE" >&2
+        exit 2
+        ;;
+    esac
+    if db_go; then
+        STATE=$(($STATE + 1))
+    else
+        STATE=$(($STATE - 1))
+    fi
+done
+
+# proper exit (0 or 1) above
+errmsg "$license license could not be presented / was not accepted"
+exit 2

--- a/debian/prerm
+++ b/debian/prerm
@@ -2,10 +2,13 @@
 
 set -e
 
+rm -f /var/lib/update-notifier/package-data-downloads/ttf-mscorefonts-installer.*
+
 #DEBHELPER#
 
 if [ "$1" = "remove" ] && [ -e /var/lib/msttcorefonts/ms-fonts ]; then
 	echo "Removing the downloaded fonts..."
+	rm -f /var/lib/update-notifier/package-data-downloads/ttf-mscorefonts-installer
 	cd /usr/share/fonts/truetype/msttcorefonts && \
 		rm -f `cat /var/lib/msttcorefonts/ms-fonts`
 	rm -f '/usr/share/doc/msttcorefonts/READ_ME!.gz'

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,19 @@
 #!/usr/bin/make -f
 
+URLROOT = http://downloads.sourceforge.net/corefonts/
+
 %:
 	dh $@
 
 override_dh_auto_build:
 	cat debian/postinst.in update-ms-fonts >> debian/postinst
+
+override_dh_auto_install:
+	mkdir -p debian/tmp/usr/share/package-data-downloads
+	while read sum file; do \
+		echo "Url: $(URLROOT)$$file"; \
+		echo "Sha256: $$sum"; \
+		echo ; \
+	done < cabfiles.sha256sums > debian/tmp/usr/share/package-data-downloads/ttf-mscorefonts-installer
+	echo "Script: /usr/lib/msttcorefonts/update-ms-fonts" >> debian/tmp/usr/share/package-data-downloads/ttf-mscorefonts-installer
+	echo "Should-Download: msttcorefonts/accepted-mscorefonts-eula" >> debian/tmp/usr/share/package-data-downloads/ttf-mscorefonts-installer

--- a/debian/templates
+++ b/debian/templates
@@ -47,3 +47,122 @@ _Description: HTTP proxy to use:
  .
  Leave this option blank if you don't use a proxy server.
 
+Template: msttcorefonts/present-mscorefonts-eula
+Type: note
+Description: TrueType core fonts for the Web EULA 
+ END-USER LICENSE AGREEMENT FOR
+ MICROSOFT SOFTWARE
+ .
+ IMPORTANT-READ CAREFULLY: This Microsoft End-User License Agreement
+ ("EULA") is a legal agreement between you (either an individual or a
+ single entity) and Microsoft Corporation for the Microsoft software
+ accompanying this EULA, which includes computer software and may
+ include associated media, printed materials, and "on-line" or
+ electronic documentation ("SOFTWARE PRODUCT" or "SOFTWARE"). By
+ exercising your rights to make and use copies of the SOFTWARE
+ PRODUCT, you agree to be bound by the terms of this EULA. If you do
+ not agree to the terms of this EULA, you may not use the SOFTWARE
+ PRODUCT.
+ .
+ SOFTWARE PRODUCT LICENSE
+ The SOFTWARE PRODUCT is protected by copyright laws and international
+ copyright treaties, as well as other intellectual property laws and
+ treaties. The SOFTWARE PRODUCT is licensed, not sold.
+ .
+ 1. GRANT OF LICENSE. This EULA grants you the following rights:
+ .
+  • Installation and Use. You may install and use an unlimited number
+    of copies of the SOFTWARE PRODUCT.
+  • Reproduction and Distribution. You may reproduce and distribute
+    an unlimited number of copies of the SOFTWARE PRODUCT; provided
+    that each copy shall be a true and complete copy, including all
+    copyright and trademark notices, and shall be accompanied by a
+    copy of this EULA. Copies of the SOFTWARE PRODUCT may not be
+    distributed for profit either on a standalone basis or included
+    as part of your own product.
+ .
+ 2. DESCRIPTION OF OTHER RIGHTS AND LIMITATIONS.
+ .
+  • Limitations on Reverse Engineering, Decompilation, and
+    Disassembly. You may not reverse engineer, decompile, or
+    disassemble the SOFTWARE PRODUCT, except and only to the extent
+    that such activity is expressly permitted by applicable law
+    notwithstanding this limitation.
+  • Restrictions on Alteration. You may not rename, edit or create
+    any derivative works from the SOFTWARE PRODUCT, other than
+    subsetting when embedding them in documents.
+  • Software Transfer. You may permanently transfer all of your
+    rights under this EULA, provided the recipient agrees to the
+    terms of this EULA.
+  • Termination. Without prejudice to any other rights, Microsoft may
+    terminate this EULA if you fail to comply with the terms and
+    conditions of this EULA. In such event, you must destroy all
+    copies of the SOFTWARE PRODUCT and all of its component parts.
+ .
+ 3. COPYRIGHT. All title and copyrights in and to the SOFTWARE PRODUCT
+ (including but not limited to any images, text, and "applets"
+ incorporated into the SOFTWARE PRODUCT), the accompanying printed
+ materials, and any copies of the SOFTWARE PRODUCT are owned by
+ Microsoft or its suppliers. The SOFTWARE PRODUCT is protected by
+ copyright laws and international treaty provisions. Therefore, you
+ must treat the SOFTWARE PRODUCT like any other copyrighted material.
+ .
+ 4. U.S. GOVERNMENT RESTRICTED RIGHTS. The SOFTWARE PRODUCT and
+ documentation are provided with RESTRICTED RIGHTS. Use, duplication,
+ or disclosure by the Government is subject to restrictions as set
+ forth in subparagraph (c)(1)(ii) of the Rights in Technical Data and
+ Computer Software clause at DFARS 252.227-7013 or subparagraphs (c)
+ (1) and (2) of the Commercial Computer Software - Restricted Rights
+ at 48 CFR 52.227-19, as applicable. Manufacturer is Microsoft
+ Corporation/One Microsoft Way/Redmond, WA 98052-6399.
+ .
+ LIMITED WARRANTY
+ .
+ NO WARRANTIES. Microsoft expressly disclaims any warranty for the
+ SOFTWARE PRODUCT. The SOFTWARE PRODUCT and any related documentation
+ is provided "as is" without warranty of any kind, either express or
+ implied, including, without limitation, the implied warranties or
+ merchantability, fitness for a particular purpose, or
+ noninfringement. The entire risk arising out of use or performance of
+ the SOFTWARE PRODUCT remains with you.
+ .
+ NO LIABILITY FOR CONSEQUENTIAL DAMAGES. In no event shall Microsoft
+ or its suppliers be liable for any damages whatsoever (including,
+ without limitation, damages for loss of business profits, business
+ interruption, loss of business information, or any other pecuniary
+ loss) arising out of the use of or inability to use this Microsoft
+ product, even if Microsoft has been advised of the possibility of
+ such damages. Because some states/jurisdictions do not allow the
+ exclusion or limitation of liability for consequential or incidental
+ damages, the above limitation may not apply to you.
+ .
+ MISCELLANEOUS
+ .
+ If you acquired this product in the United States, this EULA is
+ governed by the laws of the State of Washington.
+ .
+ If this product was acquired outside the United States, then local
+ laws may apply.
+ .
+ Should you have any questions concerning this EULA, or if you desire
+ to contact Microsoft for any reason, please contact the Microsoft
+ subsidiary serving your country, or write: Microsoft Sales
+ Information Center/One Microsoft Way/Redmond, WA 98052-6399.
+ .
+ Reference: http://www.microsoft.com/typography/fontpack/eula.htm
+
+Template: msttcorefonts/accepted-mscorefonts-eula
+Type: boolean
+Default: false
+_Description: Do you accept the EULA license terms?
+ In order to install this package, you must accept the license terms, the
+ "TrueType core fonts for the Web EULA ". Not accepting will cancel the
+ installation.
+
+Template: msttcorefonts/error-mscorefonts-eula
+Type: error
+_Description: Declined "TrueType core fonts for the Web EULA "
+ If you do not agree to the "TrueType core fonts for the Web EULA " license
+ terms you cannot install this software.
+ .
+ The installation of this package will be canceled.

--- a/debian/ttf-mscorefonts-installer.lintian-overrides
+++ b/debian/ttf-mscorefonts-installer.lintian-overrides
@@ -1,1 +1,2 @@
 ttf-mscorefonts-installer: package-contains-empty-directory [usr/share/fonts/truetype/]
+ttf-mscorefonts-installer: debconf-is-not-a-registry usr/lib/msttcorefonts/update-ms-fonts

--- a/update-ms-fonts
+++ b/update-ms-fonts
@@ -5,8 +5,9 @@
 # You may freely distribute this file under the terms of the GNU General
 # Public License, version 2 or later.
 
-#abort if anything goes wrong
 #set -e
+#. /usr/share/debconf/confmodule
+
 FONTDIR=/usr/share/fonts/truetype/msttcorefonts
 
 #if [ `id -u` != 0 ] ; then
@@ -52,6 +53,25 @@ URLROOTS="https://downloads.sourceforge.net/corefonts/
 
 if [ "$URLOVERRIDE" ] ; then
     URLROOTS="$URLOVERRIDE"
+fi
+
+db_get msttcorefonts/accepted-mscorefonts-eula || true
+if [ "$RET" != "true" ]; then
+    mstt_exit_with_error "user did not accept the $license license"
+fi
+
+if [ -z "$QUIET_MODE" ] ; then
+    cat <<EOF
+
+These fonts were provided by Microsoft "in the interest of cross-
+platform compatibility".  This is no longer the case, but they are
+still available from third parties.
+
+You are free to download these fonts and use them for your own use,
+but you may not redistribute them in modified form, including changes
+to the file name or packaging format.
+
+EOF
 fi
 
 SCRATCHDIR=`mktemp -t -d ttf-mscorefonts-installer.XXXXXX`


### PR DESCRIPTION
May fix the fonts not being installed

This will replace the `master_jammy` branch

Closes pop-os/msttcorefonts#2 